### PR TITLE
Update marker to allow string labels (no validation)

### DIFF
--- a/src/components/marker.vue
+++ b/src/components/marker.vue
@@ -34,7 +34,6 @@ const props = {
     twoWay: true
   },
   label: {
-    type: Object
   },
   opacity: {
     type: Number,


### PR DESCRIPTION
It should be possible to create marker labels by setting a plain string, e.g.

`label="M"`