### PR TITLE
Webpack without vue

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,12 @@
     "build": "cross-env NODE_ENV=production webpack --progress --hide-modules"
   },
   "dependencies": {
-    "js-marker-clusterer": "github:googlemaps/js-marker-clusterer#gh-pages",
+    "js-marker-clusterer": "github:googlemaps/js-marker-clusterer#gh-pages"
+  },
+  "peerDependencies": {
+    "vue": "^1.0.0",
     "lodash": "^3.10.1",
-    "q": "^1.4.1",
-    "vue": "^1.0.0"
+    "q": "^1.4.1"
   },
   "devDependencies": {
     "babel-core": "^6.1.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,14 +1,10 @@
 /* vim: set softtabstop=2 shiftwidth=2 expandtab : */
 var webpack = require('webpack');
+var path = require('path')
+var _ = require('lodash')
 
-module.exports = {
+var baseConfig = {
   entry: './src/main.js',
-  output: {
-	path: './',
-        filename: "index.js",
-        library: ["VueGoogleMap"],
-        libraryTarget: "umd"
-  },
   module: {
     loaders: [
       {
@@ -25,7 +21,7 @@ module.exports = {
         test: /\.(png|jpg|gif)$/,
         loader: 'file?name=[name].[ext]?[hash]'
       }
-    ]
+    ],
   },
   // example: if you wish to apply custom babel options
   // instead of using vue-loader's default:
@@ -33,7 +29,50 @@ module.exports = {
     presets: ['es2015', 'stage-0'],
     plugins: ['transform-runtime']
   }
-}
+}; /* baseConfig */
+
+/**
+ * Web config uses a global Vue and Lodash object.
+ * */
+var webConfig = _.clone(baseConfig);
+webConfig.resolve = {
+    alias: {
+      'vue': path.resolve('./src/stubs/vue'),
+      'lodash': path.resolve('./src/stubs/lodash'),
+    },
+};
+webConfig.output = {
+	path: './dist',
+    filename: "vue-google-maps.js",
+    library: ["VueGoogleMap"],
+    libraryTarget: "umd"
+};
+/**
+ *  npm config allows vue-google-maps to be distributed
+ *  as an npm package without double-requiring vue
+ * */
+var npmConfig = _.clone(baseConfig);
+npmConfig.resolve = {
+    alias: {
+      'vue': path.resolve('./src/stubs-dist/vue'),
+      'lodash': path.resolve('./src/stubs-dist/lodash'),
+    },
+};
+npmConfig.module.noParse = [
+    /src\/stubs-dist/
+];
+npmConfig.output = {
+	path: './',
+    filename: "index.js",
+    library: ["VueGoogleMap"],
+    libraryTarget: "umd"
+};
+
+module.exports = [
+    webConfig,
+    npmConfig,
+];
+
 
 if (process.env.NODE_ENV === 'production') {
   console.log('THIS IS PROD');


### PR DESCRIPTION
This PR modifies the build process to create two output files:

1. `dist/vue-google-maps.js`
2. `index.js`

**Both** files **do not** contain Vue. The former requires `window.Vue` and `window._` (as `lodash`) to exist. An HTML page has to load `vue-google-maps` from CDN using:
```
<script src='https://cdnjs.cloudflare.com/ajax/libs/lodash.js/4.6.1/lodash.js'></script>
<script src='https://cdnjs.cloudflare.com/ajax/libs/vue/1.0.17/vue.common.js'></script>
<script src="dist/vue-google-maps.js"></script>
```

A project can load `vue-google-maps` from npm via.
```
require('vue-google-maps`)
```
Internally `index.js` will make an actual `require('vue')` and `require('lodash')` call.

This PR isn't perfect, because a lot of unnecessary webpack-specific libraries are still being bundled into `index.js`. I'm still not sure how to force webpack to **not** bundle its boilerplate stuff into `index.js`, but this is one step in that direction.