### PR TITLE
Fix styles prop type in cluster component

### DIFF
--- a/src/components/cluster.vue
+++ b/src/components/cluster.vue
@@ -25,7 +25,7 @@ const props = {
     twoWay: false
   },
   styles: {
-    type: Object,
+    type: Array,
     twoWay: false
   }
 };


### PR DESCRIPTION
The `styles` option in MarkerClusterer must be an `Array`, not an `Object`.