### PR TITLE
Used v-text in Place Input Component

### DIFF
--- a/src/components/placeInput.vue
+++ b/src/components/placeInput.vue
@@ -1,6 +1,6 @@
 <template>
     <label>
-        {{ label }}
+        <span v-text="label"></span>
         <input type="text" v-el:input :placeholder="placeholder" :class="class"/>
     </label>
 </template>


### PR DESCRIPTION
Data Binding for the `Label` in the PlaceInput component would break if the user had set their `Vue.config.delimiters` option to use something else than the mustache bindings.
I replaced it with a [v-text directive](http://vuejs.org/api/#v-text).

![screen shot 2016-04-05 at 15 25 26](https://cloud.githubusercontent.com/assets/2571625/14283247/d3cbebea-fb42-11e5-95e9-33bb1e3a04f3.png)
