### PR TITLE
Fixed double declaration of created() method on Marker component.

### DIFF
--- a/src/components/marker.vue
+++ b/src/components/marker.vue
@@ -127,10 +127,6 @@ export default MapComponent.extend({
     }
   },
 
-  created() {
-    this.destroyed = false;
-  },
-
   deferredReady() {
     /* Send an event to any <cluster> parent */
     this.$dispatch('register-marker', this);


### PR DESCRIPTION
The created() method was declared twice in the Marker component and caused the whole app to fail  when using strict mode in Internet Explorer (😷).