### PR TITLE
Fix invalid property default value on placeInput

### DIFF
--- a/src/components/placeInput.vue
+++ b/src/components/placeInput.vue
@@ -35,7 +35,7 @@
       types: {
           type: Array,
           twoWay: false,
-          default: []
+          default: function() { return []; }
       },
       placeholder: {
         required: false,


### PR DESCRIPTION
Resolves this Vue warning:
`Invalid default value for prop "types": Props with type Object/Array must use a factory function to return the default value.`