### PR TITLE
Update Dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "cross-env NODE_ENV=production webpack --progress --hide-modules"
   },
   "dependencies": {
-    "js-marker-clusterer": "^1.0.0"
+    "js-marker-clusterer": "1.0.0"
   },
   "peerDependencies": {
     "vue": "^1.0.0",


### PR DESCRIPTION
`npm -i` fails due to `js-marker-clusterer`. Local install works when saving using `1.0.0` and not `^1.0.0`.