### PR TITLE
replace js-marker-clusterer(unmaintained) with official fork gmaps-ma…

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "cross-env NODE_ENV=production webpack --progress --hide-modules"
   },
   "dependencies": {
-    "js-marker-clusterer": "^1.0.0"
+    "gmaps-marker-clusterer": "^1.0.0",
   },
   "peerDependencies": {
     "vue": "^1.0.0",

--- a/src/components/cluster.vue
+++ b/src/components/cluster.vue
@@ -11,7 +11,7 @@ import _ from 'lodash';
 import propsBinder from '../utils/propsBinder.js'
 import MapComponent from './mapComponent';
 import getPropsValuesMixin from '../utils/getPropsValuesMixin.js'
-require('js-marker-clusterer');
+require('gmaps-marker-clusterer');
 
 const props = {
   maxZoom: {


### PR DESCRIPTION
see : https://github.com/googlemaps/js-marker-clusterer/issues/98
It would be good, imo, to switch for this fork. Upcoming features are essential to me : css styling (via class support) and more pending PRs that will never be merged in google's repo