### PR TITLE
Fix package.json parse error

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "cross-env NODE_ENV=production webpack --progress --hide-modules"
   },
   "dependencies": {
-    "gmaps-marker-clusterer": "^1.0.0",
+    "gmaps-marker-clusterer": "^1.0.0"
   },
   "peerDependencies": {
     "vue": "^1.0.0",


### PR DESCRIPTION
Fixes the following error 

```
npm ERR! Linux 3.19.0-79-generic
npm ERR! argv "/usr/local/bin/node" "/usr/local/bin/npm" "install"
npm ERR! node v6.4.0
npm ERR! npm  v3.10.6
npm ERR! file /home/user/Projects/vue-google-maps/package.json
npm ERR! code EJSONPARSE

npm ERR! Failed to parse json
npm ERR! Trailing comma in object at 12:3
npm ERR!   },
npm ERR!   ^
npm ERR! File: /home/user/Projects/vue-google-maps/package.json
npm ERR! Failed to parse package.json data.
npm ERR! package.json must be actual JSON, not just JavaScript.
npm ERR! 
npm ERR! This is not a bug in npm.
npm ERR! Tell the package author to fix their package.json file. JSON.parse

npm ERR! Please include the following file with any support request:
npm ERR!     /home/user/Projects/vue-google-maps/npm-debug.log
```